### PR TITLE
サイドバーや検索がローカルで正しく動作しない問題を修正

### DIFF
--- a/js/kunai.js
+++ b/js/kunai.js
@@ -115,7 +115,7 @@ class Kunai {
     let crs = new CRSearch({
       onDatabase: this.onDatabase.bind(this),
     })
-    crs.database('https://cpprefjp.github.io/static/crsearch/crsearch.json')
+    crs.database('/static/crsearch/crsearch.json')
 
     let e = $('.crsearch')
     await crs.searchbox(e)


### PR DESCRIPTION
ローカルで動作させた時に、crsearch.json の取得先が cpprefjp.github.io
を向いてしまっていたので、正しくローカル側を指すように修正した。

なお、サイドバーや検索をローカルで正しく動作させるためには、本修正の他に
crsearch と site_generator の修正も必要。