### PR TITLE
docker rm がめんどくさいので自動削除するように修正

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -26,13 +26,13 @@ DOCKER_RM=${DOCKER_RM---rm}
 
 case "$1" in
   "build" ) docker build -t kunai:0.0.0-alpine docker ;;
-  "install" ) docker run $DOCKER_RM -v `pwd`:/var/src $DOCKER_IT kunai:0.0.0-alpine /bin/sh -c "cd /var/src && exec npm install $NPM_OPTS" ;;
+  "install" ) docker run $DOCKER_RM -v `pwd`:/var/src $DOCKER_IT kunai:0.0.0-alpine npm install $NPM_OPTS ;;
   "run" )
     if [ $# -lt 2 ]; then
       show_help
       exit 1
     fi
-    docker run $DOCKER_RM -v `pwd`:/var/src -p 8080:8080 $DOCKER_IT kunai:0.0.0-alpine /bin/sh -c "cd /var/src && exec npm run $2" ;;
+    docker run $DOCKER_RM -v `pwd`:/var/src -p 8080:8080 $DOCKER_IT kunai:0.0.0-alpine npm run $2 ;;
   * )
     show_help
     exit 1 ;;

--- a/docker.sh
+++ b/docker.sh
@@ -22,15 +22,17 @@ if [ -z "$DOCKER_IT" ] && [ "${DOCKER_IT:-A}" = "${DOCKER_IT-A}" ]; then
   DOCKER_IT="-it"
 fi
 
+DOCKER_RM=${DOCKER_RM---rm}
+
 case "$1" in
   "build" ) docker build -t kunai:0.0.0-alpine docker ;;
-  "install" ) docker run -v `pwd`:/var/src -p 8080:8080 $DOCKER_IT kunai:0.0.0-alpine /bin/sh -c "cd /var/src && exec npm install $NPM_OPTS" ;;
+  "install" ) docker run $DOCKER_RM -v `pwd`:/var/src $DOCKER_IT kunai:0.0.0-alpine /bin/sh -c "cd /var/src && exec npm install $NPM_OPTS" ;;
   "run" )
     if [ $# -lt 2 ]; then
       show_help
       exit 1
     fi
-    docker run -v `pwd`:/var/src -p 8080:8080 $DOCKER_IT kunai:0.0.0-alpine /bin/sh -c "cd /var/src && exec npm run $2" ;;
+    docker run $DOCKER_RM -v `pwd`:/var/src -p 8080:8080 $DOCKER_IT kunai:0.0.0-alpine /bin/sh -c "cd /var/src && exec npm run $2" ;;
   * )
     show_help
     exit 1 ;;

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,1 +1,3 @@
 FROM node:8.9.0-alpine
+
+WORKDIR /var/src


### PR DESCRIPTION
docker.sh を実行するたびに docker rm するのがめんどくさかったので、
デフォルトで終了済みコンテナを削除するようにしてみました。
一応、残っててほしい場合も考えて（あるかな？）、
DOCKER_RM= ./docker.sh
とすれば自動削除しないようにしました。

あと、ついでに install ではポートは不要なので削除しました。