### PR TITLE
imgが横幅を超える場合に横スクロールを可能にする

### DIFF
--- a/css/kunai/site/article.css
+++ b/css/kunai/site/article.css
@@ -238,6 +238,17 @@ div[itemtype="http://schema.org/Article"] {
           border: none;
         }
       }
+
+      /* 横幅を超える画像を横スクロール可能にする */
+      .scrollable {
+        overflow-x: auto;
+        -ms-overflow-style: none; /* IE, 旧Edgeでスクロールバーを表示しない */
+        scrollbar-width: none; /* Firefoxでスクロールバーを表示しない */
+      }
+      /* Chrome, Safariでスクロールバーを表示しない */
+      .scrollable::-webkit-scrollbar {
+        display: none;
+      }
     }
   }
 

--- a/js/kunai/ui/content.js
+++ b/js/kunai/ui/content.js
@@ -7,6 +7,9 @@ class Content {
     this.log.debug('initialzing...')
 
     this.log.debug(`found ${Badge.sanitize($('main[role="main"] div[itemtype="http://schema.org/Article"] .content-body span.cpp'))} badges`)
+
+    // 横幅を超える画像を横スクロール可能にするためにスクロール用のdivで囲む
+    $('div[itemprop="articleBody"]').find('img').wrap('<div class="scrollable">')
   }
 }
 


### PR DESCRIPTION
モバイルなどで閲覧したとき、画像が表示横幅を超える場合にはみ出した右側部分をページ内では見られませんでした。
(画像を別タブで開けば見ることはできました)

そのため画像が横幅を超える時は横スクロール可能としました。見栄えのためスクロールバーは非表示にしたのでページの見た目は従来と変わらない想定です。

修正後のスクリーンショットです。PCのChrome,Firefox表示とChromeのdevtoolのiPhone12Proは確認しました。
上記以外のブラウザや実機のモバイルでの確認はしていません。

Chrome
![image](https://user-images.githubusercontent.com/2772307/148761337-d902c981-e876-40c5-8d52-196bf3e71b36.png)

Firefox
![image](https://user-images.githubusercontent.com/2772307/148762407-daaa59c7-0aa9-4f90-9c8d-25d9899a4b52.png)
