### PR TITLE
#68 の修正案

### DIFF
--- a/js/kunai/ui/treeview.js
+++ b/js/kunai/ui/treeview.js
@@ -316,6 +316,12 @@ class Treeview {
       }
 
       if (ids.length > 1) {
+        if (this.page_idx.id.type === 'article' && this.page_idx.id.indexes.length > 1) {
+          const lang = $(`[data-lang-id="C++${this.page_idx.cpp_version}"]`)
+          const article = [...lang.find('li')].find(li => $(li).first().text() === this.page_idx.name)
+          this.dom.indexElems.set(this.page_idx.id, $(article))
+        }
+        
         // highlight self
         this.dom.indexElems.get(this.page_idx.id).addClass('current-page')
 

--- a/js/kunai/ui/treeview.js
+++ b/js/kunai/ui/treeview.js
@@ -317,8 +317,8 @@ class Treeview {
 
       if (ids.length > 1) {
         if (this.page_idx.id.type === 'article' && this.page_idx.id.indexes.length > 1) {
-          const lang = $(`[data-lang-id="C++${this.page_idx.cpp_version}"]`)
-          const article = [...lang.find('li')].find(li => $(li).first().text() === this.page_idx.name)
+          const selector = `[data-lang-id="C++${this.page_idx.cpp_version}"] li.article`
+          const article = [...$(selector)].find(li => li.innerText === this.page_idx.name)
           this.dom.indexElems.set(this.page_idx.id, $(article))
         }
         


### PR DESCRIPTION
#68 の修正案です。

このバグは、タイトルが同じ記事が存在するとき（「機能テストマクロ」、「更新された定義済みマクロ」など）、 `IndexId` が共通になるため `indexElems` に最終的に登録されるのが一番古い記事のものとなり、記事を開いたときにサイドバーで `current-page` に設定されるのが同じタイトルの記事のうち一番古いものになる、というものです。

とりあえず、タイトルの同じ記事が存在するときだけ、 `current-page` に設定する `<li>` 要素を DOM から直接探して `indexElems` を上書きしてしまう、というすごくゴリ押しな解決策はいかかでしょうか。