### PR TITLE
js/kunai/ui/badge: C++ (将来/廃案) バッジの属性適用の修正

### DIFF
--- a/js/kunai/ui/badge.js
+++ b/js/kunai/ui/badge.js
@@ -13,12 +13,15 @@ const sanitize = (badges) => {
     let cppv = null
     let named_version = null
     for (const c of b_classes) {
-      const cppm = c.match(/^cpp(\d[\da-zA-Z])(.*)$/)
-      if (!cppm) {
+      if (/^(?:future|archive)$/.test(c)) {
           named_version = c
+          b.attr('data-named-version', c)
           classes.push('named-version-spec')
           continue
       }
+
+      const cppm = c.match(/^cpp(\d[\da-zA-Z])(.*)$/)
+      if (!cppm) continue;
 
       b.attr('data-cpp-version', cppm[1])
       if (cppm[1].length) {


### PR DESCRIPTION
- `data-named-version` 属性を設定
- class 名として他にも `cpp` などいろいろな物がある (& 今後追加されるかもしれない) ので `cpp番号` 以外を全て受け入れるのではなくて、`future` / `archive` を明示的にチェック

crsearch 3.0.14 への更新はこの PR に含めていませんが、動作には最終的に必要です。

ちゃんと動作することはローカルで確認済みです(※crsearch については kunai/node_modules/crsearch を直接書き換えてテストしています)。

![image](https://user-images.githubusercontent.com/8982192/193220436-4eafeb6d-2bbe-4b94-ab74-4d1d15d4ca39.png)

