### PR TITLE
Fix font size of <code> on headers

### DIFF
--- a/css/kunai/site/article.css
+++ b/css/kunai/site/article.css
@@ -60,7 +60,7 @@ div[itemtype="http://schema.org/Article"] {
   code {
     border-radius: 0;
     font-family: monospace;
-    font-size: .9rem;
+    font-size: 90%;
     background-color: #EFEFEF;
     color: #232323;
 
@@ -227,7 +227,7 @@ div[itemtype="http://schema.org/Article"] {
         box-sizing: border-box;
 
         color: #444;
-        font-size: .9rem;
+        font-size: 1rem;
         border: 1px solid #CCC;
         padding: .75em .75em;
         border-radius: 6px;

--- a/css/kunai/site/article.css
+++ b/css/kunai/site/article.css
@@ -229,7 +229,7 @@ div[itemtype="http://schema.org/Article"] {
         color: #444;
         font-size: 1rem;
         border: 1px solid #CCC;
-        padding: .75em .75em;
+        padding: .675em .675em;
         border-radius: 6px;
 
         line-height: 1.5;


### PR DESCRIPTION
- https://cpprefjp.github.io/lang/cpp20/efficient_sized_delete_for_variable_sized_classes.html のようにページタイトルに `<code>` 要素があるとフォントサイズが `.9rem` になってしまう(極端に小さくなる)問題を修正
    - 「 `1rem` に対して9割がけ」を維持するため， `<pre>` 要素内については(最終的に `.9rem` になるよう) `<pre>` 側のフォントサイズを `1rem` に修正
    - 他これで問題ないか確認をお願いしたい