### PR TITLE
メンバ関数のそれぞれの項目の左隣に余計な下線が出る問題を修正

### DIFF
--- a/css/kunai/site/sidebar-ext.scss
+++ b/css/kunai/site/sidebar-ext.scss
@@ -75,9 +75,8 @@
               &:last-child {
                 &:before {
                   @include fa-patch;
-                  @extend .fa-caret-right;
 
-                  color: transparent;
+                  content: "";
                 }
               }
             }


### PR DESCRIPTION
#57 を修正しました。

**Before**
<img width="300" src="https://github.com/cpprefjp/kunai/assets/61970673/343964db-ccce-477b-bc41-a29ad99eb701">

**After**
<img width="300" src="https://github.com/cpprefjp/kunai/assets/61970673/a3f9cb6a-d079-4394-81c8-8ca4c2ea9d68">
