### PR TITLE
インラインコードブロックがはみ出さないように修正

### DIFF
--- a/css/kunai/site/article.css
+++ b/css/kunai/site/article.css
@@ -78,6 +78,11 @@ div[itemtype="http://schema.org/Article"] {
     text-decoration: underline;
   }
 
+  :not(pre)>code {
+    display: inline-table;
+    white-space: pre-wrap;
+  }
+
   .edit-button {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
長いインラインコードブロックが画面外にはみ出す問題 #142 を修正して、画面横幅より長いときは折り返すようにしました。

<img width="400" alt="スクリーンショット" src="https://github.com/cpprefjp/kunai/assets/61970673/4eb25ea2-5ff6-4df1-be90-c8f8b752dd05">
