### PR TITLE
ページ推移後にキーボードで画面スクロールできるようにした

### DIFF
--- a/css/kunai/site/article.css
+++ b/css/kunai/site/article.css
@@ -12,6 +12,8 @@ div[itemtype="http://schema.org/Article"] {
 
   position: relative;
 
+  outline: none;
+
   > .row {
     &:nth-child(2) {
       order: -12;

--- a/js/kunai/ui/content.js
+++ b/js/kunai/ui/content.js
@@ -19,6 +19,9 @@ class Content {
     // 横幅を超える画像を横スクロール可能にするためにスクロール用のdivで囲む
     $('div[itemprop="articleBody"]').find('img').wrap('<div class="scrollable">')
 
+    // ページ推移後にキーボードで画面スクロールするためにフォーカスを当てる
+    $('main[role="main"] div[itemtype="http://schema.org/Article"]').trigger('focus')
+
     this.setupTooltip()
   }
 


### PR DESCRIPTION
ページ推移後にキーボードで画面スクロールできない問題 (#75) を解決しました。

- スクロールバーのある要素をフォーカスするコードを追加しました
  - `.focus()` は jQuery で非推奨になっていたので、 `.trigger('focus')` を使いました
- フォーカス時に outline が表示されるため、 CSS でアウトラインを非表示にしました
![image](https://github.com/user-attachments/assets/89e5cabe-7456-414c-878b-f85d98128b3b)
