### PR TITLE
PlaygroundのC++バージョンをC++2cに変更

### DIFF
--- a/js/kunai/wand.js
+++ b/js/kunai/wand.js
@@ -117,8 +117,8 @@ class API {
 class Wand {
   static defaults = new Map([
     ['compiler', 'clang-head'],
-    ['options', ['warning', 'c++2a', 'cpp-pedantic-errors']],
-    ['compiler-option-raw', ['-Wall', '-Wextra', /*'-Werror'*/]],
+    ['options', ['warning', 'cpp-pedantic-errors']],
+    ['compiler-option-raw', ['-std=c++2c', '-Wall', '-Wextra', /*'-Werror'*/]],
   ])
 
   static elapsed(msec) {


### PR DESCRIPTION
PlaygroundのC++バージョンがC++2aだったので、C++2cに上げました。
