### PR TITLE
同じタイトルのページに対するサイドバーの挙動を修正

### DIFF
--- a/js/kunai/ui/treeview.js
+++ b/js/kunai/ui/treeview.js
@@ -49,7 +49,7 @@ class DOM {
   async createHeaderContent(h) {
     // this.log.debug(`createHeaderContent (${h.self.id.join()})`, e, elem, h)
     let empty = true
-    let elem = this.indexElems.get(h.self.id)
+    let elem = this.indexElems.get(h.self)
 
     if (h.classes && h.classes.length) {
       empty = false
@@ -92,19 +92,19 @@ class DOM {
     if (empty) {
       elem.addClass('empty')
     }
-    this.lazyLoaders.set(h.self.id, async () => await this.getHeader(h))
+    this.lazyLoaders.set(h.self, async () => await this.getHeader(h))
   }
 
   async getHeader(h) {
     // this.log.debug(`getHeader (${h.self.id.join()})`, h)
-    return true // this.lazyLoaders.get(h.self.id)
+    return true // this.lazyLoaders.get(h.self)
   }
 
-  async doExpand(id) {
+  async doExpand(idx) {
     // this.log.debug(`doExpand '${id.join()}'`, id)
 
-    await this.lazyLoaders.get(id)()
-    let elem = this.indexElems.get(id)
+    await this.lazyLoaders.get(idx)()
+    let elem = this.indexElems.get(idx)
     // let content_wrapper = elem.closest('.content-wrapper')
     // let content = content_wrapper.children('.content')
 
@@ -141,10 +141,10 @@ class DOM {
     }
   }
 
-  async scrollAt(id) {
-    this.log.info(`scrollAt '${id.join()}'`, id)
+  async scrollAt(idx) {
+    this.log.info(`scrollAt '${idx.id.join()}'`, idx.id)
 
-    const e = this.indexElems.get(id)
+    const e = this.indexElems.get(idx)
     const broot = e.closest('.kunai-branch')
     const croot = broot.closest('.content')
     let wrapper = croot.closest('.content-wrapper')
@@ -190,7 +190,7 @@ class DOM {
     let li = $('<li>', {class: 'article'}).append(
       $('<a>', {href: idx.url()}).text(idx.id.join())
     )
-    this.indexElems.set(idx.id, li)
+    this.indexElems.set(idx, li)
     return li
   }
 
@@ -200,7 +200,7 @@ class DOM {
         $('<a>', {href: m.url()})
           .html(await m.join_html(DOM.crOptions))
       )
-    this.indexElems.set(m.id, li)
+    this.indexElems.set(m, li)
 
     if (this.kc.getPriorityForIndex(m).index !== this.kc.prioSpecials.get('__functions__').index) {
       li.addClass('special')
@@ -210,7 +210,7 @@ class DOM {
 
   async makeClass(c) {
     let li = $('<li>', {class: 'class classy'})
-    this.indexElems.set(c.self.id, li)
+    this.indexElems.set(c.self, li)
 
     $('<a>', {class: 'self'}).attr('href', c.self.url()).html(
       await c.self.join_html(DOM.crClassOptions)
@@ -233,7 +233,7 @@ class DOM {
 
   async makeOther(o) {
     let li = $('<li>', {class: `other ${o.id.type}`})
-    this.indexElems.set(o.id, li)
+    this.indexElems.set(o, li)
 
     if (IndexID.isClassy(o.id.type)) {
       li.addClass('classy')
@@ -261,9 +261,9 @@ class DOM {
 
   async makeExpandable(elem, obj) {
     // this.log.debug(`makeExpandable '${obj.self.id.join()}'`, elem, obj)
-    this.indexElems.set(obj.self.id, elem)
+    this.indexElems.set(obj.self, elem)
     this.lazyLoaders.set(
-      obj.self.id,
+      obj.self,
       async () => { await this.createContent(obj) }
     )
 
@@ -271,7 +271,7 @@ class DOM {
 
     bar.append(
       $('<div>', {class: 'expander'}).on('click', async () => {
-        await this.doExpand(obj.self.id)
+        await this.doExpand(obj.self)
       })
     )
 
@@ -329,27 +329,21 @@ class Treeview {
         const h = this.page_idx.in_header
         this.log.info(`expanding current page header '${h.id.join()}'`, h, this.page_idx)
 
-        await this.dom.doExpand(h.id)
+        await this.dom.doExpand(h)
       } else {
         if (IType.isHeader(this.page_idx.id.type)) {
-          await this.dom.doExpand(this.page_idx.id)
+          await this.dom.doExpand(this.page_idx)
         } else {
           this.log.info(`current page '${this.page_idx.id.join()}' is not classy. nothing left to expand`)
         }
       }
 
       if (ids.length > 1) {
-        if (this.page_idx.id.type === 'article' && this.page_idx.id.indexes.length > 1) {
-          const selector = `[data-lang-id="C++${this.page_idx.cpp_version}"] li.article`
-          const article = [...$(selector)].find(li => li.innerText === this.page_idx.name)
-          this.dom.indexElems.set(this.page_idx.id, $(article))
-        }
-        
         // highlight self
-        this.dom.indexElems.get(this.page_idx.id).addClass('current-page')
+        this.dom.indexElems.get(this.page_idx).addClass('current-page')
 
         // finally, always scroll to self
-        await this.dom.scrollAt(this.page_idx.id)
+        await this.dom.scrollAt(this.page_idx)
       }
     } catch (e) {
       this.log.error(`Failed to determine current page for id '${ids.join('/')}'. Sidebar will NOT work properly! (${e})`, ids)


### PR DESCRIPTION
## 発生している問題

開いているページと同じタイトルの別ページが（同じヘッダ内に）存在するとき、サイドバーでその別ページがアクティブになる問題があります。

例えば、 [<code>reference/chrono/<strong>duration</strong>/floor</code>](https://cpprefjp.github.io/reference/chrono/duration/floor.html) を開いたとき、サイドバーでは [<code>reference/chrono/<strong>time_point</strong>/floor</code>](https://cpprefjp.github.io/reference/chrono/time_point/floor.html) がアクティブになります。
両方タイトルが `std::chrono::floor` であり、両方 `<chrono>` に含まれるため、この問題が発生します。

<img width="816" alt="image" src="https://github.com/user-attachments/assets/d75911f7-0f6e-4f3d-ad2f-c6962601319b" />

「機能テストマクロ」、「更新された定義済みマクロ」については #127 で修正しましたが、それ以外に92件もの同様の問題を持つページ組が存在することがわかりました。

## 修正のための変更

サイドバーの要素は [`IndexID`](https://github.com/cpprefjp/crsearch/blob/e70006ac53f0f54e2a2ba6ed2ad3126940fb9bdf/js/crsearch/index-id.js#L3) をキーとする連想配列で管理されていました。
`IndexID` はページのタイトル（ `名前空間::(クラス::)?タイトル` ）で決まるため、同じタイトルのページを区別することができませんでした。

そこで、 `IndexID` ではなく、ページごとに独立な [`Index`](https://github.com/cpprefjp/crsearch/blob/e70006ac53f0f54e2a2ba6ed2ad3126940fb9bdf/js/crsearch/index.js#L7) をキーとするように変更することで問題を修正しました。

この修正により #127 の変更は不要になったため削除しました。

## 付録

<details>
<summary>問題が発生するページ組の一覧</summary>

```
0: (5) ['lang/cpp11/feature_test_macros', 'lang/cpp14/feature_test_macros', 'lang/cpp17/feature_test_macros', 'lang/cpp20/feature_test_macros', 'lang/cpp23/feature_test_macros']
1: (5) ['lang/cpp11/predefined_macros', 'lang/cpp14/predefined_macros', 'lang/cpp17/predefined_macros', 'lang/cpp20/predefined_macros', 'lang/cpp23/predefined_macros']
2: (21) ['reference/chrono/day/formatter', 'reference/chrono/duration/formatter', 'reference/chrono/hh_mm_ss/formatter', 'reference/chrono/local-time-format-t/formatter', 'reference/chrono/local_info/formatter', 'reference/chrono/month/formatter', 'reference/chrono/month_day/formatter', 'reference/chrono/month_day_last/formatter', 'reference/chrono/month_weekday/formatter', 'reference/chrono/month_weekday_last/formatter', 'reference/chrono/sys_info/formatter', 'reference/chrono/weekday/formatter', 'reference/chrono/weekday_indexed/formatter', 'reference/chrono/weekday_last/formatter', 'reference/chrono/year/formatter', 'reference/chrono/year_month/formatter', 'reference/chrono/year_month_day/formatter', 'reference/chrono/year_month_day_last/formatter', 'reference/chrono/year_month_weekday/formatter', 'reference/chrono/year_month_weekday_last/formatter', 'reference/chrono/zoned_time/formatter']
3: (8) ['reference/chrono/day/from_stream', 'reference/chrono/duration/from_stream', 'reference/chrono/month/from_stream', 'reference/chrono/month_day/from_stream', 'reference/chrono/weekday/from_stream', 'reference/chrono/year/from_stream', 'reference/chrono/year_month/from_stream', 'reference/chrono/year_month_day/from_stream']
4: (10) ['reference/chrono/day/op_append', 'reference/chrono/duration/op_divide', 'reference/chrono/last_spec/op_append', 'reference/chrono/month/op_append', 'reference/chrono/month_day/op_append', 'reference/chrono/month_day_last/op_append', 'reference/chrono/month_weekday/op_append', 'reference/chrono/month_weekday_last/op_append', 'reference/chrono/year/op_append', 'reference/chrono/year_month/op_append']
5: (13) ['reference/chrono/day/op_compare_3way', 'reference/chrono/duration/op_compare_3way', 'reference/chrono/leap_second/op_compare_3way', 'reference/chrono/month/op_compare_3way', 'reference/chrono/month_day/op_compare_3way', 'reference/chrono/month_day_last/op_compare_3way', 'reference/chrono/time_point/op_compare_3way', 'reference/chrono/time_zone/op_compare_3way', 'reference/chrono/time_zone_link/op_compare_3way', 'reference/chrono/year/op_compare_3way', 'reference/chrono/year_month/op_compare_3way', 'reference/chrono/year_month_day/op_compare_3way', 'reference/chrono/year_month_day_last/op_compare_3way']
6: (21) ['reference/chrono/day/op_equal', 'reference/chrono/duration/op_equal', 'reference/chrono/leap_second/op_equal', 'reference/chrono/month/op_equal', 'reference/chrono/month_day/op_equal', 'reference/chrono/month_day_last/op_equal', 'reference/chrono/month_weekday/op_equal', 'reference/chrono/month_weekday_last/op_equal', 'reference/chrono/time_point/op_equal', 'reference/chrono/time_zone/op_equal', 'reference/chrono/time_zone_link/op_equal', 'reference/chrono/weekday/op_equal', 'reference/chrono/weekday_indexed/op_equal', 'reference/chrono/weekday_last/op_equal', 'reference/chrono/year/op_equal', 'reference/chrono/year_month/op_equal', 'reference/chrono/year_month_day/op_equal', 'reference/chrono/year_month_day_last/op_equal', 'reference/chrono/year_month_weekday/op_equal', 'reference/chrono/year_month_weekday_last/op_equal', 'reference/chrono/zoned_time/op_equal']
7: (11) ['reference/chrono/day/op_minus', 'reference/chrono/duration/op_minus', 'reference/chrono/month/op_minus', 'reference/chrono/time_point/op_minus', 'reference/chrono/weekday/op_minus', 'reference/chrono/year/op_minus', 'reference/chrono/year_month/op_minus', 'reference/chrono/year_month_day/op_minus', 'reference/chrono/year_month_day_last/op_minus', 'reference/chrono/year_month_weekday/op_minus', 'reference/chrono/year_month_weekday_last/op_minus']
8: (20) ['reference/chrono/day/op_ostream', 'reference/chrono/duration/op_ostream', 'reference/chrono/hh_mm_ss/op_ostream', 'reference/chrono/local_info/op_ostream', 'reference/chrono/month/op_ostream', 'reference/chrono/month_day/op_ostream', 'reference/chrono/month_day_last/op_ostream', 'reference/chrono/month_weekday/op_ostream', 'reference/chrono/month_weekday_last/op_ostream', 'reference/chrono/sys_info/op_ostream', 'reference/chrono/weekday/op_ostream', 'reference/chrono/weekday_indexed/op_ostream', 'reference/chrono/weekday_last/op_ostream', 'reference/chrono/year/op_ostream', 'reference/chrono/year_month/op_ostream', 'reference/chrono/year_month_day/op_ostream', 'reference/chrono/year_month_day_last/op_ostream', 'reference/chrono/year_month_weekday/op_ostream', 'reference/chrono/year_month_weekday_last/op_ostream', 'reference/chrono/zoned_time/op_ostream']
9: (11) ['reference/chrono/day/op_plus', 'reference/chrono/duration/op_plus', 'reference/chrono/month/op_plus', 'reference/chrono/time_point/op_plus', 'reference/chrono/weekday/op_plus', 'reference/chrono/year/op_plus', 'reference/chrono/year_month/op_plus', 'reference/chrono/year_month_day/op_plus', 'reference/chrono/year_month_day_last/op_plus', 'reference/chrono/year_month_weekday/op_plus', 'reference/chrono/year_month_weekday_last/op_plus']
10: (2) ['reference/chrono/duration/ceil', 'reference/chrono/time_point/ceil']
11: (2) ['reference/chrono/duration/enable_nonlocking_formatter_optimization', 'reference/chrono/zoned_time/enable_nonlocking_formatter_optimization']
12: (2) ['reference/chrono/duration/floor', 'reference/chrono/time_point/floor']
13: (3) ['reference/chrono/duration/op_greater', 'reference/chrono/leap_second/op_greater', 'reference/chrono/time_point/op_greater']
14: (3) ['reference/chrono/duration/op_greater_equal', 'reference/chrono/leap_second/op_greater_equal', 'reference/chrono/time_point/op_greater_equal']
15: (3) ['reference/chrono/duration/op_less', 'reference/chrono/leap_second/op_less', 'reference/chrono/time_point/op_less']
16: (3) ['reference/chrono/duration/op_less_equal', 'reference/chrono/leap_second/op_less_equal', 'reference/chrono/time_point/op_less_equal']
17: (2) ['reference/chrono/duration/op_not_equal', 'reference/chrono/time_point/op_not_equal']
18: (2) ['reference/chrono/duration/round', 'reference/chrono/time_point/round']
19: (2) ['reference/filesystem/directory_iterator/begin_free', 'reference/filesystem/recursive_directory_iterator/begin_free']
20: (2) ['reference/filesystem/directory_iterator/end_free', 'reference/filesystem/recursive_directory_iterator/end_free']
21: (3) ['reference/filesystem/directory_iterator/op_equal', 'reference/filesystem/path/op_equal', 'reference/filesystem/recursive_directory_iterator/op_equal']
22: (3) ['reference/filesystem/directory_iterator/op_not_equal', 'reference/filesystem/path/op_not_equal', 'reference/filesystem/recursive_directory_iterator/op_not_equal']
23: (2) ['reference/flat_map/flat_map/erase_if_free', 'reference/flat_map/flat_multimap/erase_if_free']
24: (2) ['reference/flat_map/flat_map/swap_free', 'reference/flat_map/flat_multimap/swap_free']
25: (2) ['reference/flat_map/flat_map/uses_allocator', 'reference/flat_map/flat_multimap/uses_allocator']
26: (2) ['reference/flat_set/flat_multiset/erase_if_free', 'reference/flat_set/flat_set/erase_if_free']
27: (2) ['reference/flat_set/flat_multiset/swap_free', 'reference/flat_set/flat_set/swap_free']
28: (2) ['reference/flat_set/flat_multiset/uses_allocator', 'reference/flat_set/flat_set/uses_allocator']
29: (2) ['reference/future/packaged_task/swap_free', 'reference/future/promise/swap_free']
30: (2) ['reference/future/packaged_task/uses_allocator', 'reference/future/promise/uses_allocator']
31: (3) ['reference/iterator/counted_iterator/op_minus', 'reference/iterator/move_iterator/op_minus', 'reference/iterator/reverse_iterator/op_minus']
32: (4) ['reference/iterator/istream_iterator/op_equal', 'reference/iterator/istreambuf_iterator/op_equal', 'reference/iterator/move_iterator/op_equal', 'reference/iterator/reverse_iterator/op_equal']
33: (4) ['reference/iterator/istream_iterator/op_not_equal', 'reference/iterator/istreambuf_iterator/op_not_equal', 'reference/iterator/move_iterator/op_not_equal', 'reference/iterator/reverse_iterator/op_not_equal']
34: (2) ['reference/iterator/move_iterator/iter_move', 'reference/iterator/reverse_iterator/iter_move']
35: (2) ['reference/iterator/move_iterator/iter_swap', 'reference/iterator/reverse_iterator/iter_swap']
36: (2) ['reference/iterator/move_iterator/op_compare_3way', 'reference/iterator/reverse_iterator/op_compare_3way']
37: (2) ['reference/iterator/move_iterator/op_greater', 'reference/iterator/reverse_iterator/op_greater']
38: (2) ['reference/iterator/move_iterator/op_greater_equal', 'reference/iterator/reverse_iterator/op_greater_equal']
39: (2) ['reference/iterator/move_iterator/op_less', 'reference/iterator/reverse_iterator/op_less']
40: (2) ['reference/iterator/move_iterator/op_less_equal', 'reference/iterator/reverse_iterator/op_less_equal']
41: (2) ['reference/iterator/move_iterator/op_plus', 'reference/iterator/reverse_iterator/op_plus']
42: (2) ['reference/map/map/erase_if_free', 'reference/map/multimap/erase_if_free']
43: (2) ['reference/map/map/op_compare_3way', 'reference/map/multimap/op_compare_3way']
44: (2) ['reference/map/map/op_equal', 'reference/map/multimap/op_equal']
45: (2) ['reference/map/map/op_greater', 'reference/map/multimap/op_greater']
46: (2) ['reference/map/map/op_greater_equal', 'reference/map/multimap/op_greater_equal']
47: (2) ['reference/map/map/op_less', 'reference/map/multimap/op_less']
48: (2) ['reference/map/map/op_less_equal', 'reference/map/multimap/op_less_equal']
49: (2) ['reference/map/map/op_not_equal', 'reference/map/multimap/op_not_equal']
50: (2) ['reference/map/map/swap_free', 'reference/map/multimap/swap_free']
51: (3) ['reference/memory/allocator/op_equal', 'reference/memory/shared_ptr/op_equal', 'reference/memory/unique_ptr/op_equal']
52: (3) ['reference/memory/allocator/op_not_equal', 'reference/memory/shared_ptr/op_not_equal', 'reference/memory/unique_ptr/op_not_equal']
53: (2) ['reference/memory/shared_ptr/op_compare_3way', 'reference/memory/unique_ptr/op_compare_3way']
54: (2) ['reference/memory/shared_ptr/op_greater', 'reference/memory/unique_ptr/op_greater']
55: (2) ['reference/memory/shared_ptr/op_greater_equal', 'reference/memory/unique_ptr/op_greater_equal']
56: (2) ['reference/memory/shared_ptr/op_less', 'reference/memory/unique_ptr/op_less']
57: (2) ['reference/memory/shared_ptr/op_less_equal', 'reference/memory/unique_ptr/op_less_equal']
58: (2) ['reference/memory/shared_ptr/op_ostream', 'reference/memory/unique_ptr/op_ostream']
59: (3) ['reference/memory/shared_ptr/swap_free', 'reference/memory/unique_ptr/swap_free', 'reference/memory/weak_ptr/swap_free']
60: (2) ['reference/memory_resource/memory_resource/op_equal', 'reference/memory_resource/polymorphic_allocator/op_equal']
61: (2) ['reference/memory_resource/memory_resource/op_not_equal', 'reference/memory_resource/polymorphic_allocator/op_not_equal']
62: (2) ['reference/queue/priority_queue/swap_free', 'reference/queue/queue/swap_free']
63: (26) ['reference/random/bernoulli_distribution/op_equal', 'reference/random/binomial_distribution/op_equal', 'reference/random/cauchy_distribution/op_equal', 'reference/random/chi_squared_distribution/op_equal', 'reference/random/discard_block_engine/op_equal', 'reference/random/discrete_distribution/op_equal', 'reference/random/exponential_distribution/op_equal', 'reference/random/extreme_value_distribution/op_equal', 'reference/random/fisher_f_distribution/op_equal', 'reference/random/gamma_distribution/op_equal', 'reference/random/geometric_distribution/op_equal', 'reference/random/independent_bits_engine/op_equal', 'reference/random/linear_congruential_engine/op_equal', 'reference/random/lognormal_distribution/op_equal', 'reference/random/mersenne_twister_engine/op_equal', 'reference/random/negative_binomial_distribution/op_equal', 'reference/random/normal_distribution/op_equal', 'reference/random/piecewise_constant_distribution/op_equal', 'reference/random/piecewise_linear_distribution/op_equal', 'reference/random/poisson_distribution/op_equal', 'reference/random/shuffle_order_engine/op_equal', 'reference/random/student_t_distribution/op_equal', 'reference/random/subtract_with_carry_engine/op_equal', 'reference/random/uniform_int_distribution/op_equal', 'reference/random/uniform_real_distribution/op_equal', 'reference/random/weibull_distribution/op_equal']
64: (26) ['reference/random/bernoulli_distribution/op_istream', 'reference/random/binomial_distribution/op_istream', 'reference/random/cauchy_distribution/op_istream', 'reference/random/chi_squared_distribution/op_istream', 'reference/random/discard_block_engine/op_istream', 'reference/random/discrete_distribution/op_istream', 'reference/random/exponential_distribution/op_istream', 'reference/random/extreme_value_distribution/op_istream', 'reference/random/fisher_f_distribution/op_istream', 'reference/random/gamma_distribution/op_istream', 'reference/random/geometric_distribution/op_istream', 'reference/random/independent_bits_engine/op_istream', 'reference/random/linear_congruential_engine/op_istream', 'reference/random/lognormal_distribution/op_istream', 'reference/random/mersenne_twister_engine/op_istream', 'reference/random/negative_binomial_distribution/op_istream', 'reference/random/normal_distribution/op_istream', 'reference/random/piecewise_constant_distribution/op_istream', 'reference/random/piecewise_linear_distribution/op_istream', 'reference/random/poisson_distribution/op_istream', 'reference/random/shuffle_order_engine/op_istream', 'reference/random/student_t_distribution/op_istream', 'reference/random/subtract_with_carry_engine/op_istream', 'reference/random/uniform_int_distribution/op_istream', 'reference/random/uniform_real_distribution/op_istream', 'reference/random/weibull_distribution/op_istream']
65: (26) ['reference/random/bernoulli_distribution/op_not_equal', 'reference/random/binomial_distribution/op_not_equal', 'reference/random/cauchy_distribution/op_not_equal', 'reference/random/chi_squared_distribution/op_not_equal', 'reference/random/discard_block_engine/op_not_equal', 'reference/random/discrete_distribution/op_not_equal', 'reference/random/exponential_distribution/op_not_equal', 'reference/random/extreme_value_distribution/op_not_equal', 'reference/random/fisher_f_distribution/op_not_equal', 'reference/random/gamma_distribution/op_not_equal', 'reference/random/geometric_distribution/op_not_equal', 'reference/random/independent_bits_engine/op_not_equal', 'reference/random/linear_congruential_engine/op_not_equal', 'reference/random/lognormal_distribution/op_not_equal', 'reference/random/mersenne_twister_engine/op_not_equal', 'reference/random/negative_binomial_distribution/op_not_equal', 'reference/random/normal_distribution/op_not_equal', 'reference/random/piecewise_constant_distribution/op_not_equal', 'reference/random/piecewise_linear_distribution/op_not_equal', 'reference/random/poisson_distribution/op_not_equal', 'reference/random/shuffle_order_engine/op_not_equal', 'reference/random/student_t_distribution/op_not_equal', 'reference/random/subtract_with_carry_engine/op_not_equal', 'reference/random/uniform_int_distribution/op_not_equal', 'reference/random/uniform_real_distribution/op_not_equal', 'reference/random/weibull_distribution/op_not_equal']
66: (26) ['reference/random/bernoulli_distribution/op_ostream', 'reference/random/binomial_distribution/op_ostream', 'reference/random/cauchy_distribution/op_ostream', 'reference/random/chi_squared_distribution/op_ostream', 'reference/random/discard_block_engine/op_ostream', 'reference/random/discrete_distribution/op_ostream', 'reference/random/exponential_distribution/op_ostream', 'reference/random/extreme_value_distribution/op_ostream', 'reference/random/fisher_f_distribution/op_ostream', 'reference/random/gamma_distribution/op_ostream', 'reference/random/geometric_distribution/op_ostream', 'reference/random/independent_bits_engine/op_ostream', 'reference/random/linear_congruential_engine/op_ostream', 'reference/random/lognormal_distribution/op_ostream', 'reference/random/mersenne_twister_engine/op_ostream', 'reference/random/negative_binomial_distribution/op_ostream', 'reference/random/normal_distribution/op_ostream', 'reference/random/piecewise_constant_distribution/op_ostream', 'reference/random/piecewise_linear_distribution/op_ostream', 'reference/random/poisson_distribution/op_ostream', 'reference/random/shuffle_order_engine/op_ostream', 'reference/random/student_t_distribution/op_ostream', 'reference/random/subtract_with_carry_engine/op_ostream', 'reference/random/uniform_int_distribution/op_ostream', 'reference/random/uniform_real_distribution/op_ostream', 'reference/random/weibull_distribution/op_ostream']
67: (2) ['reference/ranges/enable_borrowed_range', 'reference/ranges/subrange/enable_borrowed_range']
68: (2) ['reference/regex/basic_regex/swap_free', 'reference/regex/match_results/swap_free']
69: (2) ['reference/set/multiset/erase_if_free', 'reference/set/set/erase_if_free']
70: (2) ['reference/set/multiset/op_compare_3way', 'reference/set/set/op_compare_3way']
71: (2) ['reference/set/multiset/op_equal', 'reference/set/set/op_equal']
72: (2) ['reference/set/multiset/op_greater', 'reference/set/set/op_greater']
73: (2) ['reference/set/multiset/op_greater_equal', 'reference/set/set/op_greater_equal']
74: (2) ['reference/set/multiset/op_less', 'reference/set/set/op_less']
75: (2) ['reference/set/multiset/op_less_equal', 'reference/set/set/op_less_equal']
76: (2) ['reference/set/multiset/op_not_equal', 'reference/set/set/op_not_equal']
77: (2) ['reference/set/multiset/swap_free', 'reference/set/set/swap_free']
78: (4) ['reference/sstream/basic_istringstream/swap_free', 'reference/sstream/basic_ostringstream/swap_free', 'reference/sstream/basic_stringbuf/swap_free', 'reference/sstream/basic_stringstream/swap_free']
79: (2) ['reference/stop_token/stop_source/op_equal', 'reference/stop_token/stop_token/op_equal']
80: (2) ['reference/stop_token/stop_source/op_not_equal', 'reference/stop_token/stop_token/op_not_equal']
81: (2) ['reference/system_error/error_code/op_compare_3way', 'reference/system_error/error_condition/op_compare_3way']
82: (2) ['reference/system_error/error_code/op_less', 'reference/system_error/error_condition/op_less']
83: (2) ['reference/unordered_map/unordered_map/erase_if_free', 'reference/unordered_map/unordered_multimap/erase_if_free']
84: (2) ['reference/unordered_map/unordered_map/op_equal', 'reference/unordered_map/unordered_multimap/op_equal']
85: (2) ['reference/unordered_map/unordered_map/op_not_equal', 'reference/unordered_map/unordered_multimap/op_not_equal']
86: (2) ['reference/unordered_map/unordered_map/swap_free', 'reference/unordered_map/unordered_multimap/swap_free']
87: (2) ['reference/unordered_set/unordered_multiset/erase_if_free', 'reference/unordered_set/unordered_set/erase_if_free']
88: (2) ['reference/unordered_set/unordered_multiset/op_equal', 'reference/unordered_set/unordered_set/op_equal']
89: (2) ['reference/unordered_set/unordered_multiset/op_not_equal', 'reference/unordered_set/unordered_set/op_not_equal']
90: (2) ['reference/unordered_set/unordered_multiset/swap_free', 'reference/unordered_set/unordered_set/swap_free']
91: (3) ['start_editing/comparison_operator_template_page', 'start_editing/function_template_page', 'start_editing/type-type_template_page']
92: (3) ['start_editing/concept_template_page', 'start_editing/cpo_template_page', 'start_editing/header_template_page']
93: (2) ['start_editing/lang_template_page', 'start_editing/named_requirement_template_page']
```

</details>
