### PR TITLE
サイドバーの項目を展開したときの三角の角度を90度に変更

### DIFF
--- a/css/kunai/site/sidebar.css
+++ b/css/kunai/site/sidebar.css
@@ -262,7 +262,7 @@ main[role="main"] .kunai-sidebar.force-legacy {
           > .expandbar {
             > .expander {
               &:before {
-                transform: rotate(45deg);
+                transform: rotate(90deg);
               }
             }
           }


### PR DESCRIPTION
ヘッダ等の項目を展開したとき、三角形が45度回転するようになっていました。意図したものかは分かりませんが、90度が一般的かと思うので90度に変更しました。

**before:**
<img width="277" height="114" alt="image" src="https://github.com/user-attachments/assets/91515ab8-ab25-47ba-a5f6-ec61116c4743" />

**after:**
<img width="270" height="106" alt="image" src="https://github.com/user-attachments/assets/051cb576-5186-4411-9cec-fd0f5d242f92" />
