### PR TITLE
説明専用バッジのスタイル定義を crsearch に移動

### DIFF
--- a/css/kunai/site/badge-ext.scss
+++ b/css/kunai/site/badge-ext.scss
@@ -17,25 +17,6 @@ main[role="main"] {
 
       span.cpp {
         @include cr-badge;
-
-        &.exposition-only {
-          border-color: #666;
-          color: #666;
-          font-style: italic;
-
-          i {
-            display: none;
-          }
-
-          &::before {
-            @include fa-patch;
-            content: "\f24a"; // fa-sticky-note-o
-          }
-
-          &::after {
-            content: "説明専用";
-          }
-        }
       }
     }
   }

--- a/css/kunai/site/sidebar-ext.scss
+++ b/css/kunai/site/sidebar-ext.scss
@@ -140,29 +140,6 @@
 
       > .title > ul.badges {
         @include cr-badge-auto(".badge");
-
-        > li.badge[data-original-attr="exposition-only"] {
-          border-color: #666;
-          color: #666;
-          font-style: italic;
-
-          a {
-            color: #666;
-
-            i {
-              display: none;
-            }
-
-            &::before {
-              @include fa-patch;
-              content: "\f24a"; // fa-sticky-note-o
-            }
-          }
-        }
-
-        &.simple > li.badge[data-original-attr="exposition-only"] a::after {
-          display: block;
-        }
       }
     }
   }

--- a/css/kunai/site/sidebar.css
+++ b/css/kunai/site/sidebar.css
@@ -744,7 +744,8 @@ main[role="main"] .kunai-sidebar.force-legacy {
   ul.others > li.other {
     .cr-index {
       ul.keys {
-        display: inline-block;
+        display: inline-flex;
+        flex-direction: row;
         padding-left: 2px;
         > li.key {
           display: inline-block;

--- a/js/kunai/ui/badge.js
+++ b/js/kunai/ui/badge.js
@@ -22,6 +22,7 @@ const sanitize = (badges) => {
     let deprecated_or_removed = false
     let cppv = null
     let named_version = null
+    let exposition_only = false
     for (const c of b_classes) {
       if (/^(?:future|archive)$/.test(c)) {
           named_version = c
@@ -31,6 +32,7 @@ const sanitize = (badges) => {
       }
 
       if (c === 'exposition-only') {
+        exposition_only = true
         classes.push('exposition-only-spec')
       }
 
@@ -59,6 +61,7 @@ const sanitize = (badges) => {
 
     const lang_path = cppv ? `/lang/cpp${cppv}` :
                       named_version ? `/lang/${named_version}` :
+                      exposition_only ? '/reference/exposition-only' :
                       `/lang`
     const a_elem = $('<a>', {href: `${lang_path}.html`})
       .append($('<i>'))

--- a/js/kunai/ui/badge.js
+++ b/js/kunai/ui/badge.js
@@ -30,6 +30,10 @@ const sanitize = (badges) => {
           continue
       }
 
+      if (c === 'exposition-only') {
+        classes.push('exposition-only-spec')
+      }
+
       const cppm = c.match(/^cpp(\d[\da-zA-Z])(.*)$/)
       if (!cppm) continue;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "anser": "^1.4.9",
         "codemirror": "^5.55.0",
         "commonmark": "^0.29.1",
-        "crsearch": "cpprefjp/crsearch#cce4f38cf8e8e6710ab8d3a6e8cb308cd6e6ac13",
+        "crsearch": "cpprefjp/crsearch#61b8f30da8b694275957a23ca6cb8e855c7f4bf9",
         "font-awesome": "^4.7.0",
         "jquery": "^3.5.1",
         "normalize.css": "^8.0.1",
@@ -3826,9 +3826,9 @@
       }
     },
     "node_modules/crsearch": {
-      "version": "3.0.26",
-      "resolved": "git+ssh://git@github.com/cpprefjp/crsearch.git#cce4f38cf8e8e6710ab8d3a6e8cb308cd6e6ac13",
-      "integrity": "sha512-QlZ3LO2oH1FTKs0u1E/Zyt6vHZGG1+ZJjLpksVqdxnNiRmoWmDBfgPM+FHp/oKzs3AXhl38GvRRh+OtDdyRpPg==",
+      "version": "3.0.27",
+      "resolved": "git+ssh://git@github.com/cpprefjp/crsearch.git#61b8f30da8b694275957a23ca6cb8e855c7f4bf9",
+      "integrity": "sha512-mVwNqjCeeOPYV/WPIIoz+kPm9h88i3LEF7pwCKNE4XkoxUc73LJSY0nwu1KOWQ3RZzOzAa3KD19qWVwUFnYsJw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.3",
@@ -14713,9 +14713,9 @@
       }
     },
     "crsearch": {
-      "version": "git+ssh://git@github.com/cpprefjp/crsearch.git#cce4f38cf8e8e6710ab8d3a6e8cb308cd6e6ac13",
-      "integrity": "sha512-QlZ3LO2oH1FTKs0u1E/Zyt6vHZGG1+ZJjLpksVqdxnNiRmoWmDBfgPM+FHp/oKzs3AXhl38GvRRh+OtDdyRpPg==",
-      "from": "crsearch@cpprefjp/crsearch#cce4f38cf8e8e6710ab8d3a6e8cb308cd6e6ac13",
+      "version": "git+ssh://git@github.com/cpprefjp/crsearch.git#61b8f30da8b694275957a23ca6cb8e855c7f4bf9",
+      "integrity": "sha512-mVwNqjCeeOPYV/WPIIoz+kPm9h88i3LEF7pwCKNE4XkoxUc73LJSY0nwu1KOWQ3RZzOzAa3KD19qWVwUFnYsJw==",
+      "from": "crsearch@cpprefjp/crsearch#61b8f30da8b694275957a23ca6cb8e855c7f4bf9",
       "requires": {
         "@babel/runtime": "^7.10.3",
         "font-awesome": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "anser": "^1.4.9",
     "codemirror": "^5.55.0",
     "commonmark": "^0.29.1",
-    "crsearch": "cpprefjp/crsearch#cce4f38cf8e8e6710ab8d3a6e8cb308cd6e6ac13",
+    "crsearch": "cpprefjp/crsearch#61b8f30da8b694275957a23ca6cb8e855c7f4bf9",
     "font-awesome": "^4.7.0",
     "jquery": "^3.5.1",
     "normalize.css": "^8.0.1",


### PR DESCRIPTION
説明専用バッジのスタイルを crsearch で定義するようにする提案です。

説明専用バッジのスタイルは kunai に定義されていましたが、タイトル横に付くバッジのスタイルと、サイドバーに付くバッジのスタイルを別々の場所に定義する必要がありました。
さらに、検索結果に付くバッジのスタイルも定義する必要があり、これは対応されていませんでした。
（説明専用バッジが付くはずが、スタイルがなく「C++ (廃案)」などと同じアイコンになってしまっています。）
<img width="302" height="166" alt="image" src="https://github.com/user-attachments/assets/612440f2-b123-46a4-869f-6af08c990e6d" />

C++バージョンのバッジと同様に crsearch でスタイルを定義すれば、これらの問題は解決します。
そこで、説明専用バッジのスタイル定義を crsearch に移動し、 kunai では `class` に `exposition-only-spec` を追加するだけに変更しました。

また、バッジについての修正を加えました：
- タイトル横の説明専用バッジに /reference/exposition-only へのリンクが付くようにしました。
- サイドバーの関数名がバッジに隠れる場合があったので、隠れず改行されるようにスタイルを修正しました。
