### PR TITLE
Dockerfile の node をバージョンアップ

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.12-alpine
+FROM node:24.17-alpine
 
 RUN apk add --no-cache git
 


### PR DESCRIPTION
`serialize-javascript@7.0.5` などのライブラリが Node 18.12 をサポートしておらず、 Docker を使ったビルドに失敗するので、 Node 24.17 を使うようにしました。

失敗したCI: https://github.com/cpprefjp/site_generator/actions/runs/27864724870/job/82466759413
