### PR TITLE
CSS の長さの単位 vw, vh を dvw, dvh に置換

### DIFF
--- a/css/kunai/site/goog.css
+++ b/css/kunai/site/goog.css
@@ -15,7 +15,7 @@ main div[itemtype="http://schema.org/Article"] {
 
     box-sizing: border-box;
 
-    max-height: 60vh;
+    max-height: 60dvh;
     overflow-x: auto;
     overflow-y: scroll;
 

--- a/css/kunai/site/layout.css
+++ b/css/kunai/site/layout.css
@@ -41,7 +41,7 @@ body {
 nav[role="navigation"] {
   display: flex;
   // min-height: 3rem;
-  // max-height: 8vh;
+  // max-height: 8dvh;
 
   padding: 0 .8rem;
   box-sizing: border-box;
@@ -69,7 +69,7 @@ nav[role="navigation"] {
 
   z-index: $navbar-expand-z;
 
-  width: 100vw;
+  width: 100dvw;
   min-height: 4rem;
 
   background: #EFEFEF;
@@ -275,20 +275,20 @@ main {
         .crsearch {
           flex-basis: auto;
           min-width: 92%;
-          max-width: 94vw;
+          max-width: 94dvw;
           margin: .5rem 0 0 0;
         }
       }
     }
 
     div[itemtype="http://schema.org/Article"] + div {
-      // flex-basis: 100vw;
+      // flex-basis: 100dvw;
       flex-basis: unset;
 
       border: none;
 
       /* box-shadow: 0px 9px 16px 2px rgba(0, 0, 0, 0.8); GPUメモリ削減のため無効化 */
-      padding: 0 4vw;
+      padding: 0 4dvw;
     }
   }
 }
@@ -316,7 +316,7 @@ main {
 
   main {
     div[itemtype="http://schema.org/Article"] + div {
-      padding: 0 2vw;
+      padding: 0 2dvw;
     }
   }
 }

--- a/css/kunai/site/sidebar.css
+++ b/css/kunai/site/sidebar.css
@@ -774,7 +774,7 @@ main[role="main"] .kunai-sidebar.force-legacy {
       &[data-branch-for="headers"] {
         order: 3;
         margin-bottom: 2em;
-        max-height: 70vh;
+        max-height: 70dvh;
       }
       &[data-branch-for="articles"] {
         order: 4;

--- a/css/kunai/variables.css
+++ b/css/kunai/variables.css
@@ -1,5 +1,5 @@
-$navbar-height: 5vh;
-$main-height: calc(100vh - $navbar-height);
+$navbar-height: 5dvh;
+$main-height: calc(100dvh - $navbar-height);
 
 $nav-bg: #f8f8f8;
 


### PR DESCRIPTION
CSSの `vw`, `vh` はスマホにおいてアドレスバーなどのブラウザの UI を含むビューポート全体の長さを基準とするため、コンテンツが実際に表示される領域よりも大きくなり、画面からはみ出して見えなくなることがあります。
`dvw`, `dvh` はブラウザの UI を除いた領域を基準にするため、 `vw`, `vh` の代わりに使用することでスマホでもコンテンツがはみ出さなくなります。

cpprefjp をスマホで見た時、サイドバーの下が UI に隠れます。これが修正されます。
<img width="250" src="https://github.com/user-attachments/assets/21548eef-c5ac-4873-9ea0-c6718c1b8cc8" /><img width="250" src="https://github.com/user-attachments/assets/cad6b54e-c11e-4db5-9c7f-6a564f0b7f1f" />
